### PR TITLE
fix: メジャーパッケージのグループ化をしない

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,7 @@
     "platformAutomerge": true,
     "dependencyDashboard": true,
     "ignoreTests": false,
-    "rebaseWhen": "conflicted",
+    "rebaseWhen": "auto",
     "semanticCommits": "enabled",
     "semanticCommitScope": "deps",
     "semanticCommitType": "chore",

--- a/default.json
+++ b/default.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "group:recommended",
+        "group:monorepos"
+    ],
     "autoApprove": true,
     "automerge": true,
     "platformAutomerge": true,

--- a/default.json
+++ b/default.json
@@ -23,7 +23,6 @@
     },
     "packageRules": [
         {
-            "groupName": "Auto merge & approve disable rules",
             "matchUpdateTypes": ["major"],
             "autoApprove": false,
             "automerge": false


### PR DESCRIPTION
### 変更
- メジャーパッケージのグルーピングをしない
  - 1つのメジャーパッケージで問題がある場合に、それに引きずられてすべてのメジャーパッケージが上げられなくなってしまうため
  - e.g. https://github.com/poporonnet/kanicon-writer-front/pull/55
- 推奨・モノレポのグルーピングを有効化
  - 近いものが分散すると良くないので
- rebaseをいつでも発生するように変更
  - 毎回`If you want to rebase/retry this PR, check this box`を押すのが面倒なので
  - 代償としてPRが $n$ 個ある場合rebaseが $n(n-1)/2$ 回発生するのでうるさいかも